### PR TITLE
feat: optimize starter theme pagespeed [SPMVP-5024]

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -7,8 +7,10 @@ useHead({
 })
 
 onMounted(() => {
-  $paywall.mount()
-  $paywall.checkQuery()
+  setTimeout(() => {
+    $paywall.mount()
+    $paywall.checkQuery()
+  }, 1000)
 })
 
 useAdvertisingHandler((segments) => {

--- a/components/AppFooter.vue
+++ b/components/AppFooter.vue
@@ -13,12 +13,13 @@ const socials = computed(() => Object.entries(site.value?.socialLinks || {}) as 
     <section v-if="site.logo?.url" class="mx-auto">
       <NuxtLink to="/">
         <picture class="text-center">
-          <img
+          <nuxt-img
             :alt="site.publicationName"
             :src="site.logo.url"
             :height="site.logo.height"
             :width="site.logo.width"
-            class="max-h-20 object-contain mx-auto"
+            class="max-h-20 object-contain mx-auto w-full h-auto"
+            loading="lazy"
           />
         </picture>
       </NuxtLink>

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -42,7 +42,7 @@ const isLoggedIn = computed(() => $paywall?.authInfo.value)
       <!-- site logo -->
       <div class="grow order-1 md:order-2">
         <NuxtLink to="/" class="link-hover mx-auto block w-fit">
-          <img :alt="site.publicationName" class="max-h-12 max-w-full" :src="site.logo?.url" />
+            <nuxt-img :alt="site.publicationName" class="max-h-12 max-w-full w-full h-auto" :src="site.logo?.url" />
         </NuxtLink>
       </div>
 

--- a/components/ArticleCard.vue
+++ b/components/ArticleCard.vue
@@ -11,11 +11,12 @@ defineProps<{ article: Article }>()
       :to="`/posts/${article.slug}`"
       class="block relative mb-4 aspect-[3/2] bg-neutral-100 rounded-3xl after:content-[''] after:absolute after:inset-0 after:hover:bg-black/10 after:transition-colors after:rounded-3xl duration-500"
     >
-      <img
+      <nuxt-img
         v-if="article.cover?.url"
         :src="article.cover.url"
         :alt="article.cover?.alt"
         class="object-cover w-full h-full rounded-3xl"
+        loading="lazy"
       />
       <div v-else class="aspect-[3/2] bg-gray-100 rounded-3xl transition duration-200 ease-in" />
     </NuxtLink>

--- a/components/FrontPageCard.vue
+++ b/components/FrontPageCard.vue
@@ -21,14 +21,16 @@ const { _resolveFromMetaSync } = useResourceResolver()
 <template>
   <article class="group" :class="classArticle">
     <NuxtLink :to="article.url" class="block" :class="classHeroPhoto">
-      <ArticleHeroPhoto
+      <nuxt-img
         v-if="article.cover?.url"
-        width="405"
-        height="270"
+        width="600"
+        height="200"
         :src="article.cover.url"
         :alt="article.cover?.alt"
-        class="rounded-xl object-cover aspect-[3/2] w-full group-hover:brightness-75 transition duration-200 ease-in"
+        class="rounded-xl object-cover aspect-[3/2] w-full h-auto group-hover:brightness-75 transition duration-200 ease-in"
         :class="classHeroPhotoImg"
+        loading="lazy"
+        sizes="sm:100vw md:50vw lg:400px"
       />
       <div
         v-else

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -14,6 +14,7 @@ export default defineNuxtConfig({
     '@nuxtjs/tailwindcss',
     '@nuxtjs/color-mode',
     '@nuxtjs/html-validator',
+    '@nuxt/image-edge',
     'nuxt-icon',
     'nuxt-lodash',
   ],

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "postinstall": "nuxt prepare"
   },
   "devDependencies": {
+    "@nuxt/image-edge": "1.0.0-28008586.381b906",
     "@nuxtjs/html-validator": "^1.2.4",
     "nuxt": "^3.3.2",
     "nuxt-icon": "^0.3.3",
@@ -17,7 +18,7 @@
   "dependencies": {
     "@nuxtjs/color-mode": "^3.2.0",
     "@nuxtjs/tailwindcss": "^6.6.5",
-    "@storipress/karbon": "^0.1.3",
+    "@storipress/karbon": "^0.1.5",
     "@vueuse/nuxt": "^9.13.0"
   }
 }


### PR DESCRIPTION
## Jira
[SPMVP-5024](https://storipress-media.atlassian.net/browse/SPMVP-5024)

[//]: # 'This template is for new features, or changing an existing feature'

[//]: # 'Put the related jira links here'
[//]: # 'Please ensure there has description for the feature'

## Purpose
- Optimize starter theme pagespeed

consider lazy load paywall

[//]: # 'Please describe how the feature will affect user, e.g.'
[//]: # '- Allow to add link on image so publisher can directly link an image in static site'
[//]: # '- Adjust "Go to site" button to become "Go to Shopify" to let publisher using Shopify integration can directly go to see preview'
[//]: # (User should be one of "reader" {who read publisher's articles}, "publisher" {our users}, "developer" {us})

### For who

- [ ] reader-facing?
- [x] publisher-facing?
- [x] developer-facing?

## How did you make it?
- lazy load image: https://v1.image.nuxtjs.org/
- lazy load stripe script: https://github.com/storipress/builder-component/pull/76
- reduce entry js size: https://github.com/storipress/karbon/pull/41
- lazy load paywall mount: currently use `setTimeout()`

[//]: # 'Give a brief for the changes you made'

## 🎩 Tophat

Do a thorough 🎩. What is [tophatting](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md_)?

Consider testing:

- Existing functionality which could break due to your changes (e.g. global changes)
- New functionality being introduced. Ensure it meets intended behavior
- All different permutations (flows, states, conditions, etc) that are possible
- If you are modifying something which is used in multiple places, 🎩 all affected areas not just what you intend to change

### 🎩 Instructions

[//]: # "If it's complex, consider put a screen record here"

<img width="992" alt="截圖 2023-04-07 下午4 24 19" src="https://user-images.githubusercontent.com/35054329/230572368-f193cea3-55b2-4fc1-b23f-16f03f41120a.png">

<img width="1020" alt="截圖 2023-04-07 下午4 22 27" src="https://user-images.githubusercontent.com/35054329/230572071-336632ae-a38f-430d-bfc6-5726133541c4.png">


## Related PRs

[//]: # 'Put the related PRs here, e.g. PR in core-component'

## Checklist before requesting review

- [ ] I have done a self-review of my own code (comment on code is not required but recommended)
- [ ] I did the Tophat steps and confirm the feature is working
- [ ] I have confirmed there is no issue reported by Static Analyzer (Please double check for custom class. For other issues, if you think it's ignorable, please add `// eslint-ignore-next-line <rule name>` on it)
- [ ] I have confirmed there is no deepsource issue (if you think it's ignorable, please explain why and add a [`skipcq` comment](https://deepsource.io/blog/releases-silence-issues-in-code/))
- [ ] I confirmed that the unit test is passed (if you break it, please fix it in this PR)
- [ ] I confirmed that I didn't break E2E test (if you break it, please fix it or create a new Jira)

## Emoji Guide

<!-- from https://developers.soundcloud.com/blog/pr-templates-for-effective-pull-requests -->

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |

## Gif (optional)

![image](https://i.gifer.com/origin/b8/b842107e63c67d5674d17e0f576274fa.gif)


[SPMVP-5024]: https://storipress-media.atlassian.net/browse/SPMVP-5024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ