### PR TITLE
fix: title is html encode in search dialog [SPMVP-6282]

### DIFF
--- a/components/SearchDialog.vue
+++ b/components/SearchDialog.vue
@@ -72,7 +72,7 @@ useIntersectionObserver($dialog, ([{ isIntersecting }]) => {
                 class="-mx-7 block px-7 py-3 font-medium text-neutral-800 hover:bg-neutral-100"
                 @click="onClose"
               >
-                {{ item.title }}
+                <span v-html="item.title" />
               </NuxtLink>
             </template>
           </AisHits>


### PR DESCRIPTION
## Jira
https://storipress-media.atlassian.net/browse/SPMVP-6282

[//]: # 'This template is for logical bug fixing, e.g. button functionality, link, js condition'
[//]: # 'Put the related jira links here'
[//]: # 'Please ensure there has reproduce steps and expected/actual result in the Jira'

## Root cause

[//]: # 'Why the bug happen?'

## Purpose

[//]: # 'Please describe how the issue will affect user, e.g.'
[//]: # '- Fix the schedule button so publisher can schedule article correctly'
[//]: # '- Fix the shifting in Kanban when dragging a card to give publisher better experience'
[//]: # (User should be one of "reader" {who read publisher's articles}, "publisher" {our users}, "developer" {us})

### For who

- [x] reader-facing?
- [ ] publisher-facing?
- [ ] developer-facing?

## How did you fix it?

[//]: # 'Give a brief for the changes you made'

## Production deployment notes

[//]: # 'Please describe the production deployment notes, e.g. this changes depend on other API or module change'

## 🎩 Tophat

Do a thorough 🎩. What is [tophatting](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md_)?

Consider testing:

- Existing functionality which could break due to your changes (e.g. global changes)
- New functionality being introduced. Ensure it meets intended behavior
- All different permutations (flows, states, conditions, etc) that are possible
- If you are modifying something which is used in multiple places, 🎩 all affected areas not just what you intend to change

### 🎩 Instructions

[//]: # "If it's complex, consider put a screen record here"

Before:
<img width="535" alt="截圖 2023-08-23 下午2 24 05" src="https://github.com/storipress/karbon-starter/assets/35054329/bf633c76-9f5f-4b51-9a77-fbc1e812241f">


After:
<img width="544" alt="截圖 2023-08-23 下午2 23 33" src="https://github.com/storipress/karbon-starter/assets/35054329/ee83ee91-77a5-4a32-b21f-9643f20c3ddc">


## Related PRs

[//]: # 'Put the related PRs here, e.g. PR in core-component'

## Checklist before requesting review

- [x] I have done a self-review of my own code (comment on code is not required but recommended)
- [x] I did the Tophat steps and confirm the issue fixed
- [ ] I have confirmed there is no issue reported by Static Analyzer (Please double check for custom class. For other issues, if you think it's ignorable, please add `// eslint-ignore-next-line <rule name>` on it)
- [ ] I have confirmed there is no deepsource issue (if you think it's ignorable, please explain why and add a [`skipcq` comment](https://deepsource.io/blog/releases-silence-issues-in-code/))
- [ ] I confirmed that the unit test is passed (if you break it, please fix it in this PR)
- [ ] I confirmed that I didn't break E2E test (if you break it, please fix it or create a new Jira)

## Emoji Guide

<!-- from https://developers.soundcloud.com/blog/pr-templates-for-effective-pull-requests -->

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |

## Gif (optional)

![image](https://i.gifer.com/origin/b8/b842107e63c67d5674d17e0f576274fa.gif)
